### PR TITLE
master => main renames (default branch also renamed)

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,15 @@ Please note that the Python analysis is quite conservative, so if it is unsure w
 
 - **Step 1.** Install both the Jupyter and the Gather extension for Visual Studio Code.
 
-    <img src=https://raw.githubusercontent.com/microsoft/vscode-gather/master/images/step1.PNG>
+    <img src=https://raw.githubusercontent.com/microsoft/vscode-gather/main/images/step1.PNG>
 
 - **Step 2.** Run cells on the Interactive Window or Notebook Editor to do your work.
 
-    <img src=https://raw.githubusercontent.com/microsoft/vscode-gather/master/images/step2.PNG>
+    <img src=https://raw.githubusercontent.com/microsoft/vscode-gather/main/images/step2.PNG>
 
 - **Step 3.** When you're satisfied with a cell's output, click the Gather icon to build a new notebook or script that generates that same output.
 
-    <img src=https://raw.githubusercontent.com/microsoft/vscode-gather/master/images/step3.PNG>
+    <img src=https://raw.githubusercontent.com/microsoft/vscode-gather/main/images/step3.PNG>
 
 ## Additional Information
 

--- a/src/test/mocks/vsc/extHostedTypes.ts
+++ b/src/test/mocks/vsc/extHostedTypes.ts
@@ -2103,7 +2103,7 @@ export namespace vscMockExtHostedTypes {
             this.name = code ? `${code} (FileSystemError)` : `FileSystemError`;
 
             // workaround when extending builtin objects and when compiling to ES5, see:
-            // https://github.com/Microsoft/TypeScript-wiki/blob/master/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
+            // https://github.com/Microsoft/TypeScript-wiki/blob/main/Breaking-Changes.md#extending-built-ins-like-error-array-and-map-may-no-longer-work
             if (typeof (<any>Object).setPrototypeOf === 'function') {
                 (<any>Object).setPrototypeOf(this, FileSystemError.prototype);
             }


### PR DESCRIPTION
Did a rename of master to main for Gather. Technically there are redirects for links like this, but figured that I should clean them up at the same time. 